### PR TITLE
Fix filter functional bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -445,12 +445,12 @@ Format: `filter [n/NAME] [e/EMAIL] [p/POSITION] [hp/PHONE] [s/STATUS] [lts/SCORE
 * for `[n/NAME]` field, only applicants whose name contains the full substring will be returned, e.g. `n/Ivan Chew` will **NOT** return `Ivan Lee`.
 * `[n/NAME]` `[e/EMAIL]` `[p/POSITION]` fields are case-insensitive, e.g. `n/JOHN` will return `john`.
 * If provided, the fields `NAME`, `PHONE`, `EMAIL`, and `POSITION` must satisfy the [parameter constraints](#command-parameters-1) previously described.
-* `[lts/SCORE]` `[gts/SCORE]` fields do **NOT** include equality in filters, e.g. `gts/7` will return all applicants whose score is strictly greater than `7`.
+* `[lts/SCORE]` `[gts/SCORE]` fields include equality in filters, e.g. `gts/7` will return all applicants whose score is greater than or equal to `7`.
 
 Example:
 * `filter n/Ivan` filters the applicant list to applicants whose name contains `ivan`.
 * `filter n/Ivan p/Testing Engineer status/u` filters applicant list to applicants whose name contains `ivan` applying for the role of `testing engineer` and has a status of `Undecided`.
-* `filter gts/7` filters applicant list to applicants whose score is strictly greater than 7.
+* `filter gts/7` filters applicant list to applicants whose score is greater than or equal to `7`.
 
 
 <br>

--- a/src/main/java/seedu/staffsnap/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/staffsnap/logic/commands/FilterCommand.java
@@ -24,9 +24,8 @@ public class FilterCommand extends Command {
 
     public static final String COMMAND_WORD = "filter";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all applicants who match the descriptor.";
-    public static final String MESSAGE_FAILURE = "Please add at least one field to filter by. "
-            + "Possible fields include:" + "\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all applicants who match the descriptor."
+            + " Possible fields include:" + "\n"
             + PREFIX_NAME + " [NAME], "
             + PREFIX_EMAIL + " [EMAIL], "
             + PREFIX_POSITION + " [POSITION], "
@@ -34,8 +33,18 @@ public class FilterCommand extends Command {
             + PREFIX_STATUS + " [STATUS], "
             + PREFIX_LESS_THAN_SCORE + " [SCORE], "
             + PREFIX_GREATER_THAN_SCORE + " [SCORE]";
-    public static final String MESSAGE_SCORE_PARSE_FAILURE = "Score in lts/ or gts/ has to be a number with up to 1 "
-            + "decimal place";
+    public static final String MESSAGE_FAILURE = "Please add at least one field to filter by."
+            + " Possible fields include:" + "\n"
+            + PREFIX_NAME + " [NAME], "
+            + PREFIX_EMAIL + " [EMAIL], "
+            + PREFIX_POSITION + " [POSITION], "
+            + PREFIX_PHONE + " [PHONE], "
+            + PREFIX_STATUS + " [STATUS], "
+            + PREFIX_LESS_THAN_SCORE + " [SCORE], "
+            + PREFIX_GREATER_THAN_SCORE + " [SCORE]";
+
+    public static final String MESSAGE_SCORE_PARSE_FAILURE = "Score in lts/ or gts/ has to be a number between 0.0 "
+            + "and 10.0 inclusive.";
 
     private final CustomFilterPredicate predicate;
 

--- a/src/main/java/seedu/staffsnap/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/staffsnap/logic/commands/FilterCommand.java
@@ -25,7 +25,7 @@ public class FilterCommand extends Command {
     public static final String COMMAND_WORD = "filter";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all applicants who match the descriptor."
-            + " Possible fields include:" + "\n"
+            + "\nParameters: "
             + PREFIX_NAME + " [NAME], "
             + PREFIX_EMAIL + " [EMAIL], "
             + PREFIX_POSITION + " [POSITION], "

--- a/src/main/java/seedu/staffsnap/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/staffsnap/logic/commands/SortCommand.java
@@ -16,12 +16,13 @@ import seedu.staffsnap.model.applicant.Descriptor;
 public class SortCommand extends Command {
 
     public static final String COMMAND_WORD = "sort";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorted all Applicants. "
-            + "Parameters: "
-            + PREFIX_DESCRIPTOR + "DESCRIPTOR ";
+
     public static final String MESSAGE_SUCCESS = "Sorted all Applicants";
     public static final String MESSAGE_FAILURE = "Please add a descriptor with d/ "
             + "[name/phone/score/status/email/position].";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all Applicants based on the descriptor given. "
+            + "\nParameters: "
+            + PREFIX_DESCRIPTOR + "[name/phone/score/status/email/position] ";
 
     private final Descriptor descriptor;
     private final Boolean isDescendingOrder;

--- a/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.staffsnap.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.staffsnap.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.staffsnap.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.staffsnap.logic.parser.CliSyntax.PREFIX_GREATER_THAN_SCORE;
@@ -35,6 +36,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FilterCommand parse(String args) throws ParseException {
+        requireNonNull(args);
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
@@ -44,6 +46,20 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_POSITION, PREFIX_INTERVIEW, PREFIX_STATUS, PREFIX_LESS_THAN_SCORE,
                         PREFIX_GREATER_THAN_SCORE);
+
+
+        if (argMultimap.getValue(PREFIX_NAME).isEmpty() &&
+                argMultimap.getValue(PREFIX_PHONE).isEmpty() &&
+                argMultimap.getValue(PREFIX_EMAIL).isEmpty() &&
+                argMultimap.getValue(PREFIX_POSITION).isEmpty() &&
+                argMultimap.getValue(PREFIX_INTERVIEW).isEmpty() &&
+                argMultimap.getValue(PREFIX_STATUS).isEmpty() &&
+                argMultimap.getValue(PREFIX_LESS_THAN_SCORE).isEmpty() &&
+                argMultimap.getValue(PREFIX_GREATER_THAN_SCORE).isEmpty()
+        ) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_FAILURE));
+        }
 
         Name name = null;
         Phone phone = null;

--- a/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
@@ -48,14 +48,14 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                         PREFIX_GREATER_THAN_SCORE);
 
 
-        if (argMultimap.getValue(PREFIX_NAME).isEmpty() &&
-                argMultimap.getValue(PREFIX_PHONE).isEmpty() &&
-                argMultimap.getValue(PREFIX_EMAIL).isEmpty() &&
-                argMultimap.getValue(PREFIX_POSITION).isEmpty() &&
-                argMultimap.getValue(PREFIX_INTERVIEW).isEmpty() &&
-                argMultimap.getValue(PREFIX_STATUS).isEmpty() &&
-                argMultimap.getValue(PREFIX_LESS_THAN_SCORE).isEmpty() &&
-                argMultimap.getValue(PREFIX_GREATER_THAN_SCORE).isEmpty()
+        if (argMultimap.getValue(PREFIX_NAME).isEmpty()
+                && argMultimap.getValue(PREFIX_PHONE).isEmpty()
+                && argMultimap.getValue(PREFIX_EMAIL).isEmpty()
+                && argMultimap.getValue(PREFIX_POSITION).isEmpty()
+                && argMultimap.getValue(PREFIX_INTERVIEW).isEmpty()
+                && argMultimap.getValue(PREFIX_STATUS).isEmpty()
+                && argMultimap.getValue(PREFIX_LESS_THAN_SCORE).isEmpty()
+                && argMultimap.getValue(PREFIX_GREATER_THAN_SCORE).isEmpty()
         ) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_FAILURE));

--- a/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
@@ -40,7 +40,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_FAILURE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,

--- a/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/staffsnap/logic/parser/FilterCommandParser.java
@@ -16,7 +16,6 @@ import java.util.List;
 import seedu.staffsnap.logic.commands.FilterCommand;
 import seedu.staffsnap.logic.parser.exceptions.ParseException;
 import seedu.staffsnap.model.applicant.CustomFilterPredicate;
-import seedu.staffsnap.model.applicant.Email;
 import seedu.staffsnap.model.applicant.Name;
 import seedu.staffsnap.model.applicant.Phone;
 import seedu.staffsnap.model.applicant.Position;
@@ -63,7 +62,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
 
         Name name = null;
         Phone phone = null;
-        Email email = null;
+        String email = null;
         Position position = null;
         List<Interview> interviewList = null;
         Status status = null;
@@ -78,7 +77,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+            email = ParserUtil.parseEmailAsString(argMultimap.getValue(PREFIX_EMAIL).get());
         }
         if (argMultimap.getValue(PREFIX_POSITION).isPresent()) {
             position = ParserUtil.parsePosition(argMultimap.getValue(PREFIX_POSITION).get());

--- a/src/main/java/seedu/staffsnap/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/staffsnap/logic/parser/ParserUtil.java
@@ -128,6 +128,18 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String email} into an {@code Email}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code email} is invalid.
+     */
+    public static String parseEmailAsString(String email) throws ParseException {
+        requireNonNull(email);
+        String trimmedEmail = email.trim();
+        return trimmedEmail.toLowerCase();
+    }
+
+    /**
      * Parses a {@code String type} and {@code String rating} into a {@code Interview}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/staffsnap/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/staffsnap/logic/parser/ParserUtil.java
@@ -247,6 +247,9 @@ public class ParserUtil {
         Double result;
         try {
             result = Double.parseDouble(score);
+            if (result < 0 || result > 10) {
+                throw new NumberFormatException("Score out of range");
+            }
         } catch (NumberFormatException e) {
             throw new ParseException(FilterCommand.MESSAGE_SCORE_PARSE_FAILURE);
         }

--- a/src/main/java/seedu/staffsnap/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/staffsnap/logic/parser/SortCommandParser.java
@@ -26,7 +26,7 @@ public class SortCommandParser implements Parser<SortCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_DESCRIPTOR)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_FAILURE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DESCRIPTOR);

--- a/src/main/java/seedu/staffsnap/model/applicant/CustomFilterPredicate.java
+++ b/src/main/java/seedu/staffsnap/model/applicant/CustomFilterPredicate.java
@@ -18,7 +18,7 @@ public class CustomFilterPredicate implements Predicate<Applicant> {
     private final Name name;
     private final Phone phone;
     // Data fields
-    private final Email email;
+    private final String email;
     private final Position position;
     private final List<Interview> interviews;
     private final Status status;
@@ -34,7 +34,7 @@ public class CustomFilterPredicate implements Predicate<Applicant> {
      * @param position   Position applied for by applicant
      * @param interviews Interviews applicant has to go through
      */
-    public CustomFilterPredicate(Name name, Phone phone, Email email, Position position, List<Interview> interviews,
+    public CustomFilterPredicate(Name name, Phone phone, String email, Position position, List<Interview> interviews,
                                  Status status, Double lessThanScore, Double greaterThanScore) {
         this.name = name;
         this.phone = phone;
@@ -63,7 +63,7 @@ public class CustomFilterPredicate implements Predicate<Applicant> {
             }
         }
         if (this.email != null) {
-            if (!StringUtil.containsWordIgnoreCase(applicant.getEmail().toString(), this.email.toString())) {
+            if (!StringUtil.containsWordIgnoreCase(applicant.getEmail().toString(), this.email)) {
                 return false;
             }
         }

--- a/src/main/java/seedu/staffsnap/model/applicant/CustomFilterPredicate.java
+++ b/src/main/java/seedu/staffsnap/model/applicant/CustomFilterPredicate.java
@@ -78,12 +78,16 @@ public class CustomFilterPredicate implements Predicate<Applicant> {
             }
         }
         if (this.lessThanScore != null) {
-            if (applicant.getScore().getAverageScore() >= this.lessThanScore) {
+            System.out.println(applicant.getScore().getAverageScore());
+            System.out.println(applicant.getScore().getAverageScore() > this.lessThanScore);
+            if (applicant.getScore().getAverageScore() > this.lessThanScore) {
                 return false;
             }
         }
         if (this.greaterThanScore != null) {
-            if (applicant.getScore().getAverageScore() <= this.greaterThanScore) {
+            System.out.println(applicant.getScore().getAverageScore());
+            System.out.println(applicant.getScore().getAverageScore() > this.greaterThanScore);
+            if (applicant.getScore().getAverageScore() < this.greaterThanScore) {
                 return false;
             }
         }

--- a/src/main/java/seedu/staffsnap/model/applicant/CustomFilterPredicate.java
+++ b/src/main/java/seedu/staffsnap/model/applicant/CustomFilterPredicate.java
@@ -78,15 +78,11 @@ public class CustomFilterPredicate implements Predicate<Applicant> {
             }
         }
         if (this.lessThanScore != null) {
-            System.out.println(applicant.getScore().getAverageScore());
-            System.out.println(applicant.getScore().getAverageScore() > this.lessThanScore);
             if (applicant.getScore().getAverageScore() > this.lessThanScore) {
                 return false;
             }
         }
         if (this.greaterThanScore != null) {
-            System.out.println(applicant.getScore().getAverageScore());
-            System.out.println(applicant.getScore().getAverageScore() > this.greaterThanScore);
             if (applicant.getScore().getAverageScore() < this.greaterThanScore) {
                 return false;
             }

--- a/src/main/java/seedu/staffsnap/model/applicant/Score.java
+++ b/src/main/java/seedu/staffsnap/model/applicant/Score.java
@@ -129,6 +129,9 @@ public class Score {
      * @return averageScore The average score of the applicant.
      */
     public Double getAverageScore() {
+        if (averageScore.isNaN()) {
+            return 0.;
+        }
         return averageScore;
     }
 

--- a/src/test/java/seedu/staffsnap/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/staffsnap/logic/commands/FilterCommandTest.java
@@ -51,9 +51,9 @@ class FilterCommandTest {
         List<Interview> interviewList2 = CARL.getInterviews();
         Status status2 = CARL.getStatus();
 
-        CustomFilterPredicate firstPredicate = new CustomFilterPredicate(name1, phone1, email1, position1,
+        CustomFilterPredicate firstPredicate = new CustomFilterPredicate(name1, phone1, email1.toString(), position1,
                 interviewList1, status1, null, null);
-        CustomFilterPredicate secondPredicate = new CustomFilterPredicate(name2, phone2, email2, position2,
+        CustomFilterPredicate secondPredicate = new CustomFilterPredicate(name2, phone2, email2.toString(), position2,
                 interviewList2, status2, null, null);
 
         FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
@@ -112,7 +112,7 @@ class FilterCommandTest {
     public void execute_multipleKeywords_zeroApplicantsFound() {
         String expectedMessage = String.format(MESSAGE_APPLICANTS_LISTED_OVERVIEW, 0);
         CustomFilterPredicate predicate = new CustomFilterPredicate(ALICE.getName(), BENSON.getPhone(),
-                CARL.getEmail(), DANIEL.getPosition(), ELLE.getInterviews(), FIONA.getStatus(), null, null);
+                CARL.getEmail().toString(), DANIEL.getPosition(), ELLE.getInterviews(), FIONA.getStatus(), null, null);
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredApplicantList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/staffsnap/logic/parser/ApplicantBookParserTest.java
+++ b/src/test/java/seedu/staffsnap/logic/parser/ApplicantBookParserTest.java
@@ -103,7 +103,7 @@ public class ApplicantBookParserTest {
 
     @Test
     public void parseCommand_filter() throws Exception {
-        assertTrue(parser.parseCommand(FilterCommand.COMMAND_WORD + " " + "d/ name") instanceof FilterCommand);
+        assertTrue(parser.parseCommand(FilterCommand.COMMAND_WORD + " " + "n/ name") instanceof FilterCommand);
     }
 
     @Test

--- a/src/test/java/seedu/staffsnap/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/staffsnap/logic/parser/FilterCommandParserTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.staffsnap.logic.commands.FilterCommand;
 import seedu.staffsnap.model.applicant.CustomFilterPredicate;
-import seedu.staffsnap.model.applicant.Email;
 import seedu.staffsnap.model.applicant.Name;
 import seedu.staffsnap.model.applicant.Phone;
 import seedu.staffsnap.model.applicant.Position;
@@ -36,7 +35,7 @@ class FilterCommandParserTest {
     @Test
     void parse_emailOnly_success() {
         assertParseSuccess(parser, " e/ test@test.com", new FilterCommand(new CustomFilterPredicate(null, null,
-                new Email("test@test.com"), null, null, null, null, null)));
+                "test@test.com", null, null, null, null, null)));
     }
 
     @Test

--- a/src/test/java/seedu/staffsnap/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/staffsnap/logic/parser/FilterCommandParserTest.java
@@ -18,7 +18,7 @@ import seedu.staffsnap.model.applicant.Status;
 class FilterCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-            FilterCommand.MESSAGE_FAILURE);
+            FilterCommand.MESSAGE_USAGE);
     private FilterCommandParser parser = new FilterCommandParser();
 
 


### PR DESCRIPTION
Closes #178, #171, #169 

TODO:
- [ ] Fix #166 


Change was made to include equality with lts/ and gts/ as without it, the filter command would cause an error with applicants who have un-rated interviews