### PR TITLE
Clarify counting of spaces in keywords

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -465,7 +465,7 @@ Find applicants whose name contains a particular keyword.
 
 Format: `find KEYWORD [MORE_KEYWORDS]`
 
-* The total length of the keywords should not be more than 55 characters long.
+* The total length of the keywords, including spaces, should not be more than 55 characters long.
 * The search is case-insensitive, e.g. `JOHN` will return `john`.
 * The order of the keywords does not matter, e.g. `Alice Tan` will match `Tan Alice`.
 * Only the applicant name is searched.

--- a/src/main/java/seedu/staffsnap/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/staffsnap/logic/commands/FindCommand.java
@@ -23,7 +23,7 @@ public class FindCommand extends Command {
     public static final String MESSAGE_WRONG_FORMAT = "Keyword(s) must be alphanumerical!"
             + "\nExample: LEE2, lee, Johnny Haw";
 
-    public static final String MESSAGE_TOO_LONG = "Please keep the keyword(s) to 55 or less characters!";
+    public static final String MESSAGE_TOO_LONG = "Please keep the keyword(s) to 55 or less characters including spaces!";
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/staffsnap/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/staffsnap/logic/commands/FindCommand.java
@@ -23,7 +23,8 @@ public class FindCommand extends Command {
     public static final String MESSAGE_WRONG_FORMAT = "Keyword(s) must be alphanumerical!"
             + "\nExample: LEE2, lee, Johnny Haw";
 
-    public static final String MESSAGE_TOO_LONG = "Please keep the keyword(s) to 55 or less characters including spaces!";
+    public static final String MESSAGE_TOO_LONG =
+            "Please keep the keyword(s) to 55 or less characters including spaces!";
 
     private final NameContainsKeywordsPredicate predicate;
 


### PR DESCRIPTION
Change to "Length of keywords, **including spaces**, should not exceed 55 characters in length" for find command